### PR TITLE
feat: add CATAcode CRAN publication links and updates

### DIFF
--- a/content/authors/admin/_index.md
+++ b/content/authors/admin/_index.md
@@ -60,7 +60,7 @@ His research includes three interconnected lines of inquiry:
 
 **Methodological Innovations**
 
-Dr. Merrin led the development of **CATAcode**, an innovative R package that addresses critical gaps in measuring and analyzing identity categories in social science research. This tool provides principled methods for coding Check-All-That-Apply demographic items, offering significant contributions to transparency, generalizability, and reproducibility in research.
+Dr. Merrin led the development of **CATAcode**, an innovative R package that addresses critical gaps in measuring and analyzing identity categories in social science research. Now published on [CRAN](https://cran.r-project.org/web/packages/CATAcode/index.html), this tool provides principled methods for coding Check-All-That-Apply demographic items, offering significant contributions to transparency, generalizability, and reproducibility in research. The package includes comprehensive documentation and a [detailed vignette](https://cran.r-project.org/web/packages/CATAcode/vignettes/CATAcode-overview.html) demonstrating its applications across diverse research contexts.
 
 **Recognition & Awards**
 

--- a/content/home/lab.md
+++ b/content/home/lab.md
@@ -70,7 +70,7 @@ The **Methodology, Adolescent Development, and Prevention (MAP) Lab** combines c
 
 - **NIJ Funding**: Leading nationwide study on bias-based harassment prevention with Boston University collaboration
 - **Prevention Innovation**: Groundbreaking work on differential effectiveness of school-based prevention programs
-- **Methodological Contributions**: Development of CATAcode R package for demographic data analysis
+- **Methodological Contributions**: [CATAcode R package](https://cran.r-project.org/web/packages/CATAcode/index.html) now published on CRAN for demographic data analysis
 - **Open Science**: Committed to reproducible research and transparent methodological practices
 - **Community Engagement**: Translating research findings into actionable prevention strategies
 

--- a/content/lab/_index.md
+++ b/content/lab/_index.md
@@ -82,6 +82,7 @@ Our lab specializes in:
 - **Network analysis** for understanding peer relationships
 - **Reproducible workflows** using R, Python, and version control
 - **Community-based participatory research** methods
+- **Demographic data analysis** using our [CATAcode R package](https://cran.r-project.org/web/packages/CATAcode/index.html)
 
 ## Collaborate With Us
 
@@ -96,6 +97,9 @@ We welcome collaborations with:
 
 ### Publications & Presentations
 Our lab has published extensively in top-tier journals including *Prevention Science*, *Journal of School Mental Health*, *Psychology of Violence*, and *Developmental Psychology*.
+
+### CATAcode R Package
+Our lab developed **CATAcode**, an innovative R package now published on [CRAN](https://cran.r-project.org/web/packages/CATAcode/index.html) that addresses critical gaps in measuring and analyzing identity categories in social science research. The package provides principled methods for coding Check-All-That-Apply demographic items and includes a [comprehensive vignette](https://cran.r-project.org/web/packages/CATAcode/vignettes/CATAcode-overview.html) with practical examples.
 
 ### Data & Code Sharing
 We are committed to open science practices and regularly share de-identified datasets and analysis code to advance the field.

--- a/content/publication/merrin-accepted-catacode/index.md
+++ b/content/publication/merrin-accepted-catacode/index.md
@@ -13,7 +13,7 @@ authors:
   - "M."
   - "Espelage"
   - "D."
-date: "accepted-01-01"
+date: "2024-01-01"
 doi: ""
 
 # Publication type
@@ -23,7 +23,7 @@ publication_types: ["2"]
 publication: "*Advances in Methods and Practices in Psychological Science.*"
 publication_short: "Advances in Methods and Practices in Psychological Science."
 
-abstract: "CATAcode provides a principled approach for coding check-all-that-apply demographic items in survey research. This R package implements systematic methods for handling multiple response data."
+abstract: "CATAcode provides a principled approach for coding check-all-that-apply demographic items in survey research. This R package implements systematic methods for handling multiple response data, offering significant contributions to transparency, generalizability, and reproducibility in research. Now available on CRAN with comprehensive documentation and vignettes."
 
 # Summary
 summary: ""
@@ -46,6 +46,7 @@ links:
 
 url_pdf: ""
 url_code: "https://github.com/knickodem/CATAcode"
+url_source: "https://cran.r-project.org/web/packages/CATAcode/index.html"
 url_dataset: ""
 url_poster: ""
 url_project: ""
@@ -66,8 +67,25 @@ projects: []
 slides: ""
 ---
 
-CATAcode provides a principled approach for coding check-all-that-apply demographic items in survey research. This R package implements systematic methods for handling multiple response data.
+CATAcode provides a principled approach for coding check-all-that-apply demographic items in survey research. This R package implements systematic methods for handling multiple response data, offering significant contributions to transparency, generalizability, and reproducibility in research.
 
-**GitHub Repository:** [CATAcode R Package](https://github.com/knickodem/CATAcode)
+The package addresses critical gaps in measuring and analyzing identity categories in social science research by providing principled methods for coding Check-All-That-Apply demographic items.
 
-**Status:** Submitted to CRAN - will be available in R soon!
+## Package Resources
+
+**📦 CRAN Package:** [CATAcode on CRAN](https://cran.r-project.org/web/packages/CATAcode/index.html)
+
+**📚 Documentation:** [Package Vignette](https://cran.r-project.org/web/packages/CATAcode/vignettes/CATAcode-overview.html)
+
+**💻 GitHub Repository:** [CATAcode R Package](https://github.com/knickodem/CATAcode)
+
+## Installation
+
+The package can now be installed directly from CRAN:
+
+```r
+install.packages("CATAcode")
+library(CATAcode)
+```
+
+**Status:** ✅ **Published on CRAN** - Available for installation in R!


### PR DESCRIPTION
- Updated author bio with CATAcode CRAN links and enhanced description
- Added CRAN package link to homepage lab section
- Enhanced lab page with dedicated CATAcode section including:
  * CRAN package link
  * Comprehensive vignette reference
  * Integration in research methods section
- Updated CATAcode publication page with:
  * CRAN package URL as source link
  * Installation instructions
  * Enhanced abstract with CRAN status
  * Resource links for easy access

CATAcode R package is now officially published on CRAN at: https://cran.r-project.org/web/packages/CATAcode/index.html

Package vignette available at:
https://cran.r-project.org/web/packages/CATAcode/vignettes/CATAcode-overview.html